### PR TITLE
Add resource reader support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
+# go-mcp
 
+A minimal Go implementation of a Model Context Protocol (MCP) server library.
+
+This repository contains a toy demo based on the "builder's guide".

--- a/cmd/mcp-stdio/main.go
+++ b/cmd/mcp-stdio/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/cyrusaf/mcp/registry"
+	"github.com/cyrusaf/mcp/rpc"
+	"github.com/cyrusaf/mcp/transport"
+)
+
+type User struct {
+	ID     int    `mcp:"id,primary"`
+	Handle string `mcp:"handle,unique"`
+}
+
+type CreateUserReq struct{ Handle string }
+type CreateUserResp struct{ ID int }
+
+func CreateUser(ctx context.Context, in CreateUserReq) (CreateUserResp, error) {
+	return CreateUserResp{ID: 1}, nil
+}
+
+func main() {
+	api := registry.New()
+	registry.RegisterResource[User](api, registry.WithURI("users://{id}"))
+	registry.RegisterTool(api, "CreateUser", CreateUser, registry.WithDescription("Create a new user account"))
+	srv := rpc.NewServer(api, transport.StdioTransport())
+	log.Fatal(srv.Run(context.Background()))
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/cyrusaf/mcp
+
+go 1.22

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,0 +1,110 @@
+package registry
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"sync"
+
+	"github.com/cyrusaf/mcp/schema"
+)
+
+type Registry struct {
+	mu        sync.RWMutex
+	resources []*ResourceDesc
+	tools     []*ToolDesc
+}
+
+func New() *Registry { return &Registry{} }
+
+func RegisterResource[T any](r *Registry, opts ...ResourceOption) *Registry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	desc := &ResourceDesc{}
+	for _, opt := range opts {
+		opt(desc)
+	}
+	var zero T
+	if desc.JSONSchema == nil {
+		if desc.Handler != nil {
+			desc.JSONSchema = schema.ReflectFromType(desc.Handler.Resp())
+		} else {
+			desc.JSONSchema = schema.ReflectFromType(reflect.TypeOf(zero))
+		}
+	}
+	r.resources = append(r.resources, desc)
+	return r
+}
+
+func RegisterTool[Req any, Resp any](r *Registry, name string, fn func(context.Context, Req) (Resp, error), opts ...ToolOption) *Registry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	desc := &ToolDesc{Name: name, Handler: HandlerFunc(fn)}
+	for _, opt := range opts {
+		opt(desc)
+	}
+	desc.InputSchema = schema.ReflectFromType(desc.Handler.Req())
+	desc.OutputSchema = schema.ReflectFromType(desc.Handler.Resp())
+	r.tools = append(r.tools, desc)
+	return r
+}
+
+func (r *Registry) Tools() []*ToolDesc {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]*ToolDesc, len(r.tools))
+	for i, t := range r.tools {
+		clone := *t
+		clone.Handler = nil
+		out[i] = &clone
+	}
+	return out
+}
+
+func (r *Registry) Resources() []*ResourceDesc {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]*ResourceDesc, len(r.resources))
+	for i, res := range r.resources {
+		clone := *res
+		out[i] = &clone
+	}
+	return out
+}
+
+func (r *Registry) findResource(uri string) *ResourceDesc {
+	for _, res := range r.resources {
+		tmpl := res.URI
+		if tmpl == uri {
+			return res
+		}
+		if i := strings.Index(tmpl, "{"); i > 0 {
+			prefix := tmpl[:i]
+			if strings.HasPrefix(uri, prefix) {
+				return res
+			}
+		}
+	}
+	return nil
+}
+
+func (r *Registry) FindResource(uri string) *ResourceDesc {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.findResource(uri)
+}
+
+func (r *Registry) findTool(name string) *ToolDesc {
+	for _, t := range r.tools {
+		if t.Name == name {
+			return t
+		}
+	}
+	return nil
+}
+
+func (r *Registry) FindTool(name string) *ToolDesc {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.findTool(name)
+}

--- a/registry/resource.go
+++ b/registry/resource.go
@@ -1,0 +1,51 @@
+package registry
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/cyrusaf/mcp/schema"
+)
+
+type ResourceDesc struct {
+	URI        string             `json:"uri"`
+	JSONSchema *schema.Schema     `json:"json_schema,omitempty"`
+	Handler    rawResourceHandler `json:"-"`
+}
+
+type rawResourceHandler interface {
+	Resp() reflect.Type
+	Read(ctx context.Context, uri string) (any, error)
+}
+
+type resourceHandlerFunc[Resp any] struct {
+	f func(context.Context, string) (Resp, error)
+}
+
+func (h *resourceHandlerFunc[Resp]) Resp() reflect.Type {
+	var v Resp
+	return reflect.TypeOf(v)
+}
+
+func (h *resourceHandlerFunc[Resp]) Read(ctx context.Context, uri string) (any, error) {
+	return h.f(ctx, uri)
+}
+
+func ResourceHandlerFunc[Resp any](fn func(context.Context, string) (Resp, error)) rawResourceHandler {
+	return &resourceHandlerFunc[Resp]{f: fn}
+}
+
+type ResourceOption func(*ResourceDesc)
+
+func WithURI(uri string) ResourceOption {
+	return func(r *ResourceDesc) { r.URI = uri }
+}
+
+func WithSchema(s *schema.Schema) ResourceOption {
+	return func(r *ResourceDesc) { r.JSONSchema = s }
+}
+
+func WithReadHandler[Resp any](fn func(context.Context, string) (Resp, error)) ResourceOption {
+	h := ResourceHandlerFunc(fn)
+	return func(r *ResourceDesc) { r.Handler = h }
+}

--- a/registry/tool.go
+++ b/registry/tool.go
@@ -1,0 +1,57 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"reflect"
+
+	"github.com/cyrusaf/mcp/schema"
+)
+
+var ErrInvalidParams = errors.New("invalid params")
+
+type ToolDesc struct {
+	Name         string         `json:"name"`
+	Description  string         `json:"description,omitempty"`
+	InputSchema  *schema.Schema `json:"input_schema,omitempty"`
+	OutputSchema *schema.Schema `json:"output_schema,omitempty"`
+	Handler      rawHandler     `json:"-"`
+}
+
+type rawHandler interface {
+	Req() reflect.Type
+	Resp() reflect.Type
+	Call(ctx context.Context, req any) (any, error)
+}
+
+type ToolOption func(*ToolDesc)
+
+func WithDescription(desc string) ToolOption {
+	return func(t *ToolDesc) { t.Description = desc }
+}
+
+type handlerFunc[Req any, Resp any] struct {
+	f func(context.Context, Req) (Resp, error)
+}
+
+func (h *handlerFunc[Req, Resp]) Req() reflect.Type {
+	var v Req
+	return reflect.TypeOf(v)
+}
+
+func (h *handlerFunc[Req, Resp]) Resp() reflect.Type {
+	var v Resp
+	return reflect.TypeOf(v)
+}
+
+func (h *handlerFunc[Req, Resp]) Call(ctx context.Context, req any) (any, error) {
+	r, ok := req.(Req)
+	if !ok {
+		return nil, ErrInvalidParams
+	}
+	return h.f(ctx, r)
+}
+
+func HandlerFunc[Req any, Resp any](fn func(context.Context, Req) (Resp, error)) rawHandler {
+	return &handlerFunc[Req, Resp]{f: fn}
+}

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -1,0 +1,16 @@
+package rpc
+
+import "fmt"
+
+type Error struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type rpcError = Error
+
+func ErrorMethodNotFound(method string) *Error {
+	return &Error{Code: -32601, Message: fmt.Sprintf("method not found: %s", method)}
+}
+
+var ErrInvalidParams = &Error{Code: -32602, Message: "invalid params"}

--- a/rpc/messages.go
+++ b/rpc/messages.go
@@ -1,0 +1,19 @@
+package rpc
+
+import "encoding/json"
+
+// JSON-RPC request/response structures
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  any             `json:"result,omitempty"`
+	Error   *Error          `json:"error,omitempty"`
+}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -1,0 +1,128 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"reflect"
+
+	"github.com/cyrusaf/mcp/registry"
+	"github.com/cyrusaf/mcp/transport"
+)
+
+// Server dispatches JSON-RPC requests
+
+type Server struct {
+	reg *registry.Registry
+	tr  transport.Transport
+}
+
+func NewServer(reg *registry.Registry, tr transport.Transport) *Server {
+	return &Server{reg: reg, tr: tr}
+}
+
+func (s *Server) Run(ctx context.Context) error {
+	for {
+		raw, err := s.tr.Next(ctx)
+		if err != nil {
+			return err
+		}
+		go s.handle(ctx, raw)
+	}
+}
+
+func (s *Server) handle(ctx context.Context, raw json.RawMessage) {
+	var req rpcRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		s.sendError(ctx, nil, ErrInvalidParams)
+		return
+	}
+
+	switch req.Method {
+	case "initialize":
+		res := map[string]any{"capabilities": map[string]any{"tools": map[string]any{}, "resources": map[string]any{}}}
+		s.send(ctx, req.ID, res)
+	case "tools/list":
+		s.send(ctx, req.ID, s.reg.Tools())
+	case "resources/list":
+		s.send(ctx, req.ID, s.reg.Resources())
+	case "tools/call":
+		s.handleToolCall(ctx, req)
+	case "resources/read":
+		s.handleResourceRead(ctx, req)
+	default:
+		s.sendError(ctx, req.ID, ErrorMethodNotFound(req.Method))
+	}
+}
+
+func (s *Server) send(ctx context.Context, id json.RawMessage, result any) {
+	resp := rpcResponse{JSONRPC: "2.0", ID: id, Result: result}
+	data, _ := json.Marshal(resp)
+	_ = s.tr.Send(ctx, data)
+}
+
+func (s *Server) sendError(ctx context.Context, id json.RawMessage, err *Error) {
+	resp := rpcResponse{JSONRPC: "2.0", ID: id, Error: err}
+	data, _ := json.Marshal(resp)
+	_ = s.tr.Send(ctx, data)
+}
+
+// tools/call params structure
+
+type callParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+func (s *Server) handleToolCall(ctx context.Context, req rpcRequest) {
+	var params callParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		s.sendError(ctx, req.ID, ErrInvalidParams)
+		return
+	}
+	tool := s.reg.FindTool(params.Name)
+	if tool == nil {
+		s.sendError(ctx, req.ID, ErrorMethodNotFound(params.Name))
+		return
+	}
+	// decode arguments
+	arg := reflect.New(tool.Handler.Req()).Interface()
+	if len(params.Arguments) > 0 {
+		if err := json.Unmarshal(params.Arguments, &arg); err != nil {
+			s.sendError(ctx, req.ID, ErrInvalidParams)
+			return
+		}
+	}
+	val, err := tool.Handler.Call(ctx, reflect.ValueOf(arg).Elem().Interface())
+	if err != nil {
+		s.sendError(ctx, req.ID, &Error{Code: -32000, Message: err.Error()})
+		return
+	}
+	s.send(ctx, req.ID, val)
+}
+
+func (s *Server) handleResourceRead(ctx context.Context, req rpcRequest) {
+	type params struct {
+		URI string `json:"uri"`
+	}
+	var p params
+	if err := json.Unmarshal(req.Params, &p); err != nil || p.URI == "" {
+		s.sendError(ctx, req.ID, ErrInvalidParams)
+		return
+	}
+	if _, err := url.Parse(p.URI); err != nil {
+		s.sendError(ctx, req.ID, ErrInvalidParams)
+		return
+	}
+	res := s.reg.FindResource(p.URI)
+	if res == nil || res.Handler == nil {
+		s.sendError(ctx, req.ID, ErrorMethodNotFound(p.URI))
+		return
+	}
+	val, err := res.Handler.Read(ctx, p.URI)
+	if err != nil {
+		s.sendError(ctx, req.ID, &Error{Code: -32000, Message: err.Error()})
+		return
+	}
+	s.send(ctx, req.ID, val)
+}

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -1,0 +1,196 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cyrusaf/mcp/registry"
+)
+
+type memTransport struct {
+	in  chan json.RawMessage
+	out chan json.RawMessage
+}
+
+func newMemTransport() *memTransport {
+	return &memTransport{
+		in:  make(chan json.RawMessage, 10),
+		out: make(chan json.RawMessage, 10),
+	}
+}
+
+func (m *memTransport) Next(ctx context.Context) (json.RawMessage, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case msg, ok := <-m.in:
+		if !ok {
+			return nil, io.EOF
+		}
+		return msg, nil
+	}
+}
+
+func (m *memTransport) Send(ctx context.Context, resp json.RawMessage) error {
+	m.out <- resp
+	return nil
+}
+
+func (m *memTransport) Close() error { return nil }
+
+func startTestServer(t *testing.T) (*Server, *memTransport, context.CancelFunc) {
+	tr := newMemTransport()
+	reg := registry.New()
+	registry.RegisterResource[struct{ ID int }](reg,
+		registry.WithURI("res://{id}"),
+		registry.WithReadHandler(func(ctx context.Context, uri string) (struct{ ID int }, error) {
+			parts := strings.Split(uri, "res://")
+			if len(parts) != 2 {
+				return struct{ ID int }{}, errors.New("bad uri")
+			}
+			id, _ := strconv.Atoi(parts[1])
+			return struct{ ID int }{ID: id}, nil
+		}))
+	registry.RegisterTool(reg, "Echo", func(ctx context.Context, in struct{ Msg string }) (struct{ Msg string }, error) {
+		return in, nil
+	}, registry.WithDescription("echo a message"))
+	srv := NewServer(reg, tr)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = srv.Run(ctx) }()
+	return srv, tr, cancel
+}
+
+func TestToolsList(t *testing.T) {
+	_, tr, cancel := startTestServer(t)
+	defer cancel()
+
+	req := rpcRequest{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list"}
+	data, _ := json.Marshal(req)
+	tr.in <- data
+
+	respBytes := <-tr.out
+	var resp rpcResponse
+	if err := json.Unmarshal(respBytes, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	var tools []registry.ToolDesc
+	if b, err := json.Marshal(resp.Result); err == nil {
+		_ = json.Unmarshal(b, &tools)
+	}
+	if len(tools) != 1 || tools[0].Name != "Echo" {
+		t.Fatalf("unexpected tools: %+v", tools)
+	}
+}
+
+func TestToolsCall(t *testing.T) {
+	_, tr, cancel := startTestServer(t)
+	defer cancel()
+
+	params := callParams{Name: "Echo", Arguments: json.RawMessage(`{"Msg":"hi"}`)}
+	pbytes, _ := json.Marshal(params)
+	req := rpcRequest{JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: "tools/call", Params: pbytes}
+	data, _ := json.Marshal(req)
+	tr.in <- data
+
+	respBytes := <-tr.out
+	var resp rpcResponse
+	if err := json.Unmarshal(respBytes, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	b, _ := json.Marshal(resp.Result)
+	var out struct{ Msg string }
+	_ = json.Unmarshal(b, &out)
+	if out.Msg != "hi" {
+		t.Fatalf("unexpected result: %+v", out)
+	}
+}
+
+func TestResourcesList(t *testing.T) {
+	_, tr, cancel := startTestServer(t)
+	defer cancel()
+
+	req := rpcRequest{JSONRPC: "2.0", ID: json.RawMessage(`3`), Method: "resources/list"}
+	data, _ := json.Marshal(req)
+	tr.in <- data
+
+	respBytes := <-tr.out
+	var resp rpcResponse
+	if err := json.Unmarshal(respBytes, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	var res []registry.ResourceDesc
+	if b, err := json.Marshal(resp.Result); err == nil {
+		_ = json.Unmarshal(b, &res)
+	}
+	if len(res) != 1 || res[0].URI != "res://{id}" {
+		t.Fatalf("unexpected resources: %+v", res)
+	}
+}
+
+func TestToolsDescription(t *testing.T) {
+	_, tr, cancel := startTestServer(t)
+	defer cancel()
+
+	req := rpcRequest{JSONRPC: "2.0", ID: json.RawMessage(`4`), Method: "tools/list"}
+	data, _ := json.Marshal(req)
+	tr.in <- data
+
+	respBytes := <-tr.out
+	var resp rpcResponse
+	if err := json.Unmarshal(respBytes, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	var tools []registry.ToolDesc
+	if b, err := json.Marshal(resp.Result); err == nil {
+		_ = json.Unmarshal(b, &tools)
+	}
+	if len(tools) != 1 || tools[0].Description != "echo a message" {
+		t.Fatalf("unexpected tools: %+v", tools)
+	}
+}
+
+func TestResourceRead(t *testing.T) {
+	_, tr, cancel := startTestServer(t)
+	defer cancel()
+
+	params := struct {
+		URI string `json:"uri"`
+	}{URI: "res://42"}
+	pbytes, _ := json.Marshal(params)
+	req := rpcRequest{JSONRPC: "2.0", ID: json.RawMessage(`5`), Method: "resources/read", Params: pbytes}
+	data, _ := json.Marshal(req)
+	tr.in <- data
+
+	respBytes := <-tr.out
+	var resp rpcResponse
+	if err := json.Unmarshal(respBytes, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	var out struct{ ID int }
+	if b, err := json.Marshal(resp.Result); err == nil {
+		_ = json.Unmarshal(b, &out)
+	}
+	if out.ID != 42 {
+		t.Fatalf("unexpected result: %+v", out)
+	}
+}

--- a/schema/jsonschema.go
+++ b/schema/jsonschema.go
@@ -1,0 +1,39 @@
+package schema
+
+import "reflect"
+
+type Schema struct {
+	Type       string             `json:"type,omitempty"`
+	Properties map[string]*Schema `json:"properties,omitempty"`
+	Items      *Schema            `json:"items,omitempty"`
+}
+
+func ReflectFromType(t reflect.Type) *Schema {
+	switch t.Kind() {
+	case reflect.String:
+		return &Schema{Type: "string"}
+	case reflect.Bool:
+		return &Schema{Type: "boolean"}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return &Schema{Type: "integer"}
+	case reflect.Float32, reflect.Float64:
+		return &Schema{Type: "number"}
+	case reflect.Slice, reflect.Array:
+		return &Schema{Type: "array", Items: ReflectFromType(t.Elem())}
+	case reflect.Struct:
+		props := make(map[string]*Schema)
+		for i := 0; i < t.NumField(); i++ {
+			f := t.Field(i)
+			if f.PkgPath != "" { // unexported
+				continue
+			}
+			props[f.Name] = ReflectFromType(f.Type)
+		}
+		return &Schema{Type: "object", Properties: props}
+	default:
+		return &Schema{Type: "object"}
+	}
+}
+
+func Reflect(v any) *Schema { return ReflectFromType(reflect.TypeOf(v)) }

--- a/transport/stdio.go
+++ b/transport/stdio.go
@@ -1,0 +1,39 @@
+package transport
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+)
+
+type Transport interface {
+	Next(ctx context.Context) (json.RawMessage, error)
+	Send(ctx context.Context, resp json.RawMessage) error
+	Close() error
+}
+
+type stdioTransport struct {
+	in  *bufio.Reader
+	out io.Writer
+}
+
+func StdioTransport() Transport {
+	return &stdioTransport{in: bufio.NewReader(os.Stdin), out: os.Stdout}
+}
+
+func (s *stdioTransport) Next(ctx context.Context) (json.RawMessage, error) {
+	line, err := s.in.ReadBytes('\n')
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(line), nil
+}
+
+func (s *stdioTransport) Send(ctx context.Context, resp json.RawMessage) error {
+	_, err := s.out.Write(append(resp, '\n'))
+	return err
+}
+
+func (s *stdioTransport) Close() error { return nil }


### PR DESCRIPTION
## Summary
- extend Resource registration to include read handlers
- implement resource lookup and calling in the RPC server
- register a read handler in tests and assert returned data

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68451699b8fc83218a23e48c106d7c7a