### PR TITLE
Implement http transport

### DIFF
--- a/cmd/mcp-http/main.go
+++ b/cmd/mcp-http/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/cyrusaf/mcp/registry"
+	"github.com/cyrusaf/mcp/rpc"
+	"github.com/cyrusaf/mcp/transport"
+)
+
+// This example exposes the MCP server over HTTP.
+type User struct {
+	ID     int    `mcp:"id,primary"`
+	Handle string `mcp:"handle,unique"`
+}
+
+type CreateUserReq struct{ Handle string }
+type CreateUserResp struct{ ID int }
+
+func CreateUser(ctx context.Context, in CreateUserReq) (CreateUserResp, error) {
+	return CreateUserResp{ID: 1}, nil
+}
+
+func main() {
+	api := registry.New()
+	registry.RegisterResource[User](api, registry.WithURI("users://{id}"))
+	registry.RegisterTool(api, "CreateUser", CreateUser, registry.WithDescription("Create a new user account"))
+
+	tr := transport.HTTPTransport(":8080")
+	srv := rpc.NewServer(api, tr)
+	log.Fatal(srv.Run(context.Background()))
+}

--- a/transport/http.go
+++ b/transport/http.go
@@ -1,0 +1,107 @@
+package transport
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"sync"
+)
+
+type httpMessage struct {
+	id     string
+	req    json.RawMessage
+	respCh chan json.RawMessage
+}
+
+type httpTransport struct {
+	srv     *http.Server
+	reqCh   chan httpMessage
+	mu      sync.Mutex
+	pending map[string]chan json.RawMessage
+}
+
+// HTTPTransport returns a Transport that serves JSON-RPC requests over HTTP.
+// It listens on the provided address.
+func HTTPTransport(addr string) Transport {
+	tr := &httpTransport{
+		reqCh:   make(chan httpMessage, 16),
+		pending: make(map[string]chan json.RawMessage),
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", tr.handle)
+	tr.srv = &http.Server{Addr: addr, Handler: mux}
+	go tr.srv.ListenAndServe()
+	return tr
+}
+
+func (h *httpTransport) handle(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	var tmp struct {
+		ID json.RawMessage `json:"id"`
+	}
+	_ = json.Unmarshal(body, &tmp)
+	msg := httpMessage{
+		id:     string(tmp.ID),
+		req:    json.RawMessage(body),
+		respCh: make(chan json.RawMessage, 1),
+	}
+	select {
+	case h.reqCh <- msg:
+	case <-r.Context().Done():
+		return
+	}
+	resp := <-msg.respCh
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(resp)
+}
+
+func (h *httpTransport) Next(ctx context.Context) (json.RawMessage, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case msg, ok := <-h.reqCh:
+		if !ok {
+			return nil, io.EOF
+		}
+		if msg.id != "" {
+			h.mu.Lock()
+			h.pending[msg.id] = msg.respCh
+			h.mu.Unlock()
+		}
+		return msg.req, nil
+	}
+}
+
+func (h *httpTransport) Send(ctx context.Context, resp json.RawMessage) error {
+	var tmp struct {
+		ID json.RawMessage `json:"id"`
+	}
+	if err := json.Unmarshal(resp, &tmp); err != nil {
+		return err
+	}
+	id := string(tmp.ID)
+	h.mu.Lock()
+	ch, ok := h.pending[id]
+	if ok {
+		delete(h.pending, id)
+	}
+	h.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	select {
+	case ch <- resp:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (h *httpTransport) Close() error {
+	return h.srv.Shutdown(context.Background())
+}


### PR DESCRIPTION
## Summary
- add HTTP transport using Go's standard library http server
- add example command serving MCP over HTTP

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68452317a8a0832181141dd3b02402db