### PR TITLE
Add HTTP transport e2e test and simplify transport

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -23,18 +23,18 @@ func NewServer(reg *registry.Registry, tr transport.Transport) *Server {
 
 func (s *Server) Run(ctx context.Context) error {
 	for {
-		raw, err := s.tr.Next(ctx)
+		conn, raw, err := s.tr.Next(ctx)
 		if err != nil {
 			return err
 		}
-		go s.handle(ctx, raw)
+		go s.handle(ctx, conn, raw)
 	}
 }
 
-func (s *Server) handle(ctx context.Context, raw json.RawMessage) {
+func (s *Server) handle(ctx context.Context, conn transport.Conn, raw json.RawMessage) {
 	var req rpcRequest
 	if err := json.Unmarshal(raw, &req); err != nil {
-		s.sendError(ctx, nil, ErrInvalidParams)
+		s.sendError(ctx, conn, nil, ErrInvalidParams)
 		return
 	}
 
@@ -53,30 +53,30 @@ func (s *Server) handle(ctx context.Context, raw json.RawMessage) {
 				Resources: s.reg.Resources(),
 			},
 		}
-		s.send(ctx, req.ID, res)
+		s.send(ctx, conn, req.ID, res)
 	case "tools/list":
-		s.send(ctx, req.ID, s.reg.Tools())
+		s.send(ctx, conn, req.ID, s.reg.Tools())
 	case "resources/list":
-		s.send(ctx, req.ID, s.reg.Resources())
+		s.send(ctx, conn, req.ID, s.reg.Resources())
 	case "tools/call":
-		s.handleToolCall(ctx, req)
+		s.handleToolCall(ctx, conn, req)
 	case "resources/read":
-		s.handleResourceRead(ctx, req)
+		s.handleResourceRead(ctx, conn, req)
 	default:
-		s.sendError(ctx, req.ID, ErrorMethodNotFound(req.Method))
+		s.sendError(ctx, conn, req.ID, ErrorMethodNotFound(req.Method))
 	}
 }
 
-func (s *Server) send(ctx context.Context, id json.RawMessage, result any) {
+func (s *Server) send(ctx context.Context, conn transport.Conn, id json.RawMessage, result any) {
 	resp := rpcResponse{JSONRPC: "2.0", ID: id, Result: result}
 	data, _ := json.Marshal(resp)
-	_ = s.tr.Send(ctx, data)
+	_ = conn.Send(ctx, data)
 }
 
-func (s *Server) sendError(ctx context.Context, id json.RawMessage, err *Error) {
+func (s *Server) sendError(ctx context.Context, conn transport.Conn, id json.RawMessage, err *Error) {
 	resp := rpcResponse{JSONRPC: "2.0", ID: id, Error: err}
 	data, _ := json.Marshal(resp)
-	_ = s.tr.Send(ctx, data)
+	_ = conn.Send(ctx, data)
 }
 
 // tools/call params structure
@@ -86,55 +86,55 @@ type callParams struct {
 	Arguments json.RawMessage `json:"arguments"`
 }
 
-func (s *Server) handleToolCall(ctx context.Context, req rpcRequest) {
+func (s *Server) handleToolCall(ctx context.Context, conn transport.Conn, req rpcRequest) {
 	var params callParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		s.sendError(ctx, req.ID, ErrInvalidParams)
+		s.sendError(ctx, conn, req.ID, ErrInvalidParams)
 		return
 	}
 	tool := s.reg.FindTool(params.Name)
 	if tool == nil {
-		s.sendError(ctx, req.ID, ErrorMethodNotFound(params.Name))
+		s.sendError(ctx, conn, req.ID, ErrorMethodNotFound(params.Name))
 		return
 	}
 	// decode arguments
 	arg := reflect.New(tool.Handler.Req()).Interface()
 	if len(params.Arguments) > 0 {
 		if err := json.Unmarshal(params.Arguments, &arg); err != nil {
-			s.sendError(ctx, req.ID, ErrInvalidParams)
+			s.sendError(ctx, conn, req.ID, ErrInvalidParams)
 			return
 		}
 	}
 	val, err := tool.Handler.Call(ctx, reflect.ValueOf(arg).Elem().Interface())
 	if err != nil {
-		s.sendError(ctx, req.ID, &Error{Code: -32000, Message: err.Error()})
+		s.sendError(ctx, conn, req.ID, &Error{Code: -32000, Message: err.Error()})
 		return
 	}
-	s.send(ctx, req.ID, val)
+	s.send(ctx, conn, req.ID, val)
 }
 
-func (s *Server) handleResourceRead(ctx context.Context, req rpcRequest) {
+func (s *Server) handleResourceRead(ctx context.Context, conn transport.Conn, req rpcRequest) {
 	type params struct {
 		URI string `json:"uri"`
 	}
 	var p params
 	if err := json.Unmarshal(req.Params, &p); err != nil || p.URI == "" {
-		s.sendError(ctx, req.ID, ErrInvalidParams)
+		s.sendError(ctx, conn, req.ID, ErrInvalidParams)
 		return
 	}
 	if _, err := url.Parse(p.URI); err != nil {
-		s.sendError(ctx, req.ID, ErrInvalidParams)
+		s.sendError(ctx, conn, req.ID, ErrInvalidParams)
 		return
 	}
 	res := s.reg.FindResource(p.URI)
 	if res == nil || res.Handler == nil {
-		s.sendError(ctx, req.ID, ErrorMethodNotFound(p.URI))
+		s.sendError(ctx, conn, req.ID, ErrorMethodNotFound(p.URI))
 		return
 	}
 	val, err := res.Handler.Read(ctx, p.URI)
 	if err != nil {
-		s.sendError(ctx, req.ID, &Error{Code: -32000, Message: err.Error()})
+		s.sendError(ctx, conn, req.ID, &Error{Code: -32000, Message: err.Error()})
 		return
 	}
-	s.send(ctx, req.ID, val)
+	s.send(ctx, conn, req.ID, val)
 }

--- a/transport/http_test.go
+++ b/transport/http_test.go
@@ -1,0 +1,141 @@
+package transport_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cyrusaf/mcp/registry"
+	"github.com/cyrusaf/mcp/rpc"
+	"github.com/cyrusaf/mcp/transport"
+)
+
+// helper to start server using HTTP transport
+type testHTTPTransport struct {
+	server *httptest.Server
+	reqCh  chan httpMessage
+}
+
+type httpMessage struct {
+	req  json.RawMessage
+	conn *httpConn
+}
+
+type httpConn struct{ ch chan json.RawMessage }
+
+func (c *httpConn) Send(ctx context.Context, resp json.RawMessage) error {
+	select {
+	case c.ch <- resp:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func newTestHTTPTransport() *testHTTPTransport {
+	t := &testHTTPTransport{
+		reqCh: make(chan httpMessage, 16),
+	}
+	t.server = httptest.NewServer(http.HandlerFunc(t.handle))
+	return t
+}
+
+func (t *testHTTPTransport) handle(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	conn := &httpConn{ch: make(chan json.RawMessage, 1)}
+	msg := httpMessage{req: json.RawMessage(body), conn: conn}
+	select {
+	case t.reqCh <- msg:
+	case <-r.Context().Done():
+		return
+	}
+	resp := <-conn.ch
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(resp)
+}
+
+func (t *testHTTPTransport) Next(ctx context.Context) (transport.Conn, json.RawMessage, error) {
+	select {
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	case msg, ok := <-t.reqCh:
+		if !ok {
+			return nil, nil, io.EOF
+		}
+		return msg.conn, msg.req, nil
+	}
+}
+
+func (t *testHTTPTransport) Close() error {
+	t.server.Close()
+	return nil
+}
+
+func startHTTPTestServer(tst *testing.T) (addr string, cancel func()) {
+	tst.Helper()
+
+	tr := newTestHTTPTransport()
+	addr = tr.server.URL
+
+	reg := registry.New()
+	registry.RegisterTool(reg, "Echo", func(ctx context.Context, in struct{ Msg string }) (struct{ Msg string }, error) {
+		return in, nil
+	})
+
+	srv := rpc.NewServer(reg, tr)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	go func() { _ = srv.Run(ctx) }()
+
+	cancelFunc := func() {
+		cancelCtx()
+		_ = tr.Close()
+	}
+	return addr, cancelFunc
+}
+
+func TestHTTPTransportEndToEnd(t *testing.T) {
+	url, cancel := startHTTPTestServer(t)
+	defer cancel()
+
+	req := struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Method  string          `json:"method"`
+	}{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list"}
+	data, _ := json.Marshal(req)
+
+	resp, err := http.Post(url, "application/json", bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	var out struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Result  any             `json:"result"`
+		Error   *rpc.Error      `json:"error"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Error != nil {
+		t.Fatalf("unexpected error: %v", out.Error)
+	}
+	var tools []registry.ToolDesc
+	if b, err := json.Marshal(out.Result); err == nil {
+		_ = json.Unmarshal(b, &tools)
+	}
+	if len(tools) != 1 || tools[0].Name != "Echo" {
+		t.Fatalf("unexpected tools: %+v", tools)
+	}
+}


### PR DESCRIPTION
## Summary
- add connection-based transport interface without pending map
- simplify HTTP transport implementation
- refactor RPC server and tests
- update HTTP transport test to use new interface

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68452b1f3ec483219e4f2515b45279a0