### PR TITLE
Fix initialize capabilities map

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -61,6 +61,18 @@ func (r *Registry) Tools() []*ToolDesc {
 	return out
 }
 
+func (r *Registry) ToolsMap() map[string]*ToolDesc {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make(map[string]*ToolDesc, len(r.tools))
+	for _, t := range r.tools {
+		clone := *t
+		clone.Handler = nil
+		out[t.Name] = &clone
+	}
+	return out
+}
+
 func (r *Registry) Resources() []*ResourceDesc {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -68,6 +80,17 @@ func (r *Registry) Resources() []*ResourceDesc {
 	for i, res := range r.resources {
 		clone := *res
 		out[i] = &clone
+	}
+	return out
+}
+
+func (r *Registry) ResourcesMap() map[string]*ResourceDesc {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make(map[string]*ResourceDesc, len(r.resources))
+	for _, res := range r.resources {
+		clone := *res
+		out[res.URI] = &clone
 	}
 	return out
 }

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -41,16 +41,16 @@ func (s *Server) handle(ctx context.Context, conn transport.Conn, raw json.RawMe
 	switch req.Method {
 	case "initialize":
 		type capabilities struct {
-			Tools     []*registry.ToolDesc     `json:"tools"`
-			Resources []*registry.ResourceDesc `json:"resources"`
+			Tools     map[string]*registry.ToolDesc     `json:"tools"`
+			Resources map[string]*registry.ResourceDesc `json:"resources"`
 		}
 		type initializeResult struct {
 			Capabilities capabilities `json:"capabilities"`
 		}
 		res := initializeResult{
 			Capabilities: capabilities{
-				Tools:     s.reg.Tools(),
-				Resources: s.reg.Resources(),
+				Tools:     s.reg.ToolsMap(),
+				Resources: s.reg.ResourcesMap(),
 			},
 		}
 		s.send(ctx, conn, req.ID, res)

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -220,17 +220,23 @@ func TestInitialize(t *testing.T) {
 	}
 	var out struct {
 		Capabilities struct {
-			Tools     []registry.ToolDesc     `json:"tools"`
-			Resources []registry.ResourceDesc `json:"resources"`
+			Tools     map[string]registry.ToolDesc     `json:"tools"`
+			Resources map[string]registry.ResourceDesc `json:"resources"`
 		} `json:"capabilities"`
 	}
 	if b, err := json.Marshal(resp.Result); err == nil {
 		_ = json.Unmarshal(b, &out)
 	}
-	if len(out.Capabilities.Tools) != 1 || out.Capabilities.Tools[0].Name != "Echo" {
+	if len(out.Capabilities.Tools) != 1 {
 		t.Fatalf("unexpected initialize tools: %+v", out.Capabilities.Tools)
 	}
-	if len(out.Capabilities.Resources) != 1 || out.Capabilities.Resources[0].URI != "res://{id}" {
+	if _, ok := out.Capabilities.Tools["Echo"]; !ok {
+		t.Fatalf("initialize tools missing Echo: %+v", out.Capabilities.Tools)
+	}
+	if len(out.Capabilities.Resources) != 1 {
 		t.Fatalf("unexpected initialize resources: %+v", out.Capabilities.Resources)
+	}
+	if _, ok := out.Capabilities.Resources["res://{id}"]; !ok {
+		t.Fatalf("initialize resources missing res://{id}: %+v", out.Capabilities.Resources)
 	}
 }


### PR DESCRIPTION
## Summary
- provide tools and resources as keyed maps
- adjust server initialize handler to return maps
- expect maps in initialize test cases

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6845344c5f308321b40e2d7f4fd2cd0f