### PR TITLE
Add resource template tests and update register API

### DIFF
--- a/cmd/mcp-http/main.go
+++ b/cmd/mcp-http/main.go
@@ -11,7 +11,7 @@ import (
 
 // This example exposes the MCP server over HTTP.
 type User struct {
-	ID     int    `mcp:"id,primary"`
+	ID     string `mcp:"id,primary"`
 	Handle string `mcp:"handle,unique"`
 }
 
@@ -24,10 +24,16 @@ func CreateUser(ctx context.Context, in CreateUserReq) (CreateUserResp, error) {
 
 func main() {
 	api := registry.New()
-	registry.RegisterResource[User](api, registry.WithURI("users://{id}"))
+	registry.RegisterResource[User](api, "User", "users://{id}", UserHandler)
+	registry.RegisterResourceTemplate[User](api, "User", "users://{id}", UserHandler)
+
 	registry.RegisterTool(api, "CreateUser", CreateUser, registry.WithDescription("Create a new user account"))
 
 	tr := transport.HTTPTransport(":8080")
 	srv := rpc.NewServer(api, tr)
 	log.Fatal(srv.Run(context.Background()))
+}
+
+func UserHandler(ctx context.Context, id string) (User, error) {
+	return User{ID: id}, nil
 }

--- a/cmd/mcp-stdio/main.go
+++ b/cmd/mcp-stdio/main.go
@@ -23,7 +23,7 @@ func CreateUser(ctx context.Context, in CreateUserReq) (CreateUserResp, error) {
 
 func main() {
 	api := registry.New()
-	registry.RegisterResource[User](api, registry.WithURI("users://{id}"))
+	registry.RegisterResource[User](api, "User", "users://{id}", func(context.Context, string) (User, error) { return User{}, nil })
 	registry.RegisterTool(api, "CreateUser", CreateUser, registry.WithDescription("Create a new user account"))
 	srv := rpc.NewServer(api, transport.StdioTransport())
 	log.Fatal(srv.Run(context.Background()))

--- a/registry/resource.go
+++ b/registry/resource.go
@@ -8,6 +8,7 @@ import (
 )
 
 type ResourceDesc struct {
+	Name       string             `json:"name"`
 	URI        string             `json:"uri"`
 	JSONSchema *schema.Schema     `json:"json_schema,omitempty"`
 	Handler    rawResourceHandler `json:"-"`
@@ -37,15 +38,6 @@ func ResourceHandlerFunc[Resp any](fn func(context.Context, string) (Resp, error
 
 type ResourceOption func(*ResourceDesc)
 
-func WithURI(uri string) ResourceOption {
-	return func(r *ResourceDesc) { r.URI = uri }
-}
-
 func WithSchema(s *schema.Schema) ResourceOption {
 	return func(r *ResourceDesc) { r.JSONSchema = s }
-}
-
-func WithReadHandler[Resp any](fn func(context.Context, string) (Resp, error)) ResourceOption {
-	h := ResourceHandlerFunc(fn)
-	return func(r *ResourceDesc) { r.Handler = h }
 }

--- a/registry/resource_template.go
+++ b/registry/resource_template.go
@@ -1,0 +1,43 @@
+package registry
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/cyrusaf/mcp/schema"
+)
+
+type ResourceTemplateDesc struct {
+	Name        string             `json:"name"`
+	URITemplate string             `json:"uriTemplate"`
+	JSONSchema  *schema.Schema     `json:"json_schema,omitempty"`
+	Handler     rawResourceHandler `json:"-"`
+}
+
+type rawResourceTemplateHandler interface {
+	Resp() reflect.Type
+	Read(ctx context.Context, uri string) (any, error)
+}
+
+type resourceTemplateHandlerFunc[Resp any] struct {
+	f func(context.Context, string) (Resp, error)
+}
+
+func (h *resourceTemplateHandlerFunc[Resp]) Resp() reflect.Type {
+	var v Resp
+	return reflect.TypeOf(v)
+}
+
+func (h *resourceTemplateHandlerFunc[Resp]) Read(ctx context.Context, uri string) (any, error) {
+	return h.f(ctx, uri)
+}
+
+func ResourceTemplateHandlerFunc[Resp any](fn func(context.Context, string) (Resp, error)) rawResourceHandler {
+	return &resourceHandlerFunc[Resp]{f: fn}
+}
+
+type ResourceTemplateOption func(*ResourceTemplateDesc)
+
+func WithTemplateSchema(s *schema.Schema) ResourceTemplateOption {
+	return func(r *ResourceTemplateDesc) { r.JSONSchema = s }
+}

--- a/registry/tool.go
+++ b/registry/tool.go
@@ -12,8 +12,8 @@ var ErrInvalidParams = errors.New("invalid params")
 
 type ToolDesc struct {
 	Name         string         `json:"name"`
-	Description  string         `json:"description,omitempty"`
-	InputSchema  *schema.Schema `json:"input_schema,omitempty"`
+	Description  string         `json:"description"`
+	InputSchema  schema.Schema  `json:"input_schema"`
 	OutputSchema *schema.Schema `json:"output_schema,omitempty"`
 	Handler      rawHandler     `json:"-"`
 }

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -53,16 +53,16 @@ func (m *memTransport) Close() error { return nil }
 func startTestServer(t *testing.T) (*Server, *memTransport, context.CancelFunc) {
 	tr := newMemTransport()
 	reg := registry.New()
-	registry.RegisterResource[struct{ ID int }](reg,
-		registry.WithURI("res://{id}"),
-		registry.WithReadHandler(func(ctx context.Context, uri string) (struct{ ID int }, error) {
-			parts := strings.Split(uri, "res://")
-			if len(parts) != 2 {
-				return struct{ ID int }{}, errors.New("bad uri")
-			}
-			id, _ := strconv.Atoi(parts[1])
-			return struct{ ID int }{ID: id}, nil
-		}))
+	handler := func(ctx context.Context, uri string) (struct{ ID int }, error) {
+		parts := strings.Split(uri, "res://")
+		if len(parts) != 2 {
+			return struct{ ID int }{}, errors.New("bad uri")
+		}
+		id, _ := strconv.Atoi(parts[1])
+		return struct{ ID int }{ID: id}, nil
+	}
+	registry.RegisterResource[struct{ ID int }](reg, "Res", "res://{id}", handler)
+	registry.RegisterResourceTemplate[struct{ ID int }](reg, "Res", "res://{id}", handler)
 	registry.RegisterTool(reg, "Echo", func(ctx context.Context, in struct{ Msg string }) (struct{ Msg string }, error) {
 		return in, nil
 	}, registry.WithDescription("echo a message"))
@@ -88,12 +88,14 @@ func TestToolsList(t *testing.T) {
 	if resp.Error != nil {
 		t.Fatalf("unexpected error: %v", resp.Error)
 	}
-	var tools []registry.ToolDesc
-	if b, err := json.Marshal(resp.Result); err == nil {
-		_ = json.Unmarshal(b, &tools)
+	var out struct {
+		Tools []registry.ToolDesc `json:"tools"`
 	}
-	if len(tools) != 1 || tools[0].Name != "Echo" {
-		t.Fatalf("unexpected tools: %+v", tools)
+	if b, err := json.Marshal(resp.Result); err == nil {
+		_ = json.Unmarshal(b, &out)
+	}
+	if len(out.Tools) != 1 || out.Tools[0].Name != "Echo" {
+		t.Fatalf("unexpected tools: %+v", out.Tools)
 	}
 }
 
@@ -139,12 +141,41 @@ func TestResourcesList(t *testing.T) {
 	if resp.Error != nil {
 		t.Fatalf("unexpected error: %v", resp.Error)
 	}
-	var res []registry.ResourceDesc
-	if b, err := json.Marshal(resp.Result); err == nil {
-		_ = json.Unmarshal(b, &res)
+	var out struct {
+		Resources []registry.ResourceDesc `json:"resources"`
 	}
-	if len(res) != 1 || res[0].URI != "res://{id}" {
-		t.Fatalf("unexpected resources: %+v", res)
+	if b, err := json.Marshal(resp.Result); err == nil {
+		_ = json.Unmarshal(b, &out)
+	}
+	if len(out.Resources) != 1 || out.Resources[0].URI != "res://{id}" {
+		t.Fatalf("unexpected resources: %+v", out.Resources)
+	}
+}
+
+func TestResourceTemplatesList(t *testing.T) {
+	_, tr, cancel := startTestServer(t)
+	defer cancel()
+
+	req := rpcRequest{JSONRPC: "2.0", ID: json.RawMessage(`7`), Method: "resources/templates/list"}
+	data, _ := json.Marshal(req)
+	tr.in <- data
+
+	respBytes := <-tr.out
+	var resp rpcResponse
+	if err := json.Unmarshal(respBytes, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	var out struct {
+		ResourceTemplates []registry.ResourceTemplateDesc `json:"resourceTemplates"`
+	}
+	if b, err := json.Marshal(resp.Result); err == nil {
+		_ = json.Unmarshal(b, &out)
+	}
+	if len(out.ResourceTemplates) != 1 || out.ResourceTemplates[0].URITemplate != "res://{id}" {
+		t.Fatalf("unexpected resource templates: %+v", out.ResourceTemplates)
 	}
 }
 
@@ -164,12 +195,14 @@ func TestToolsDescription(t *testing.T) {
 	if resp.Error != nil {
 		t.Fatalf("unexpected error: %v", resp.Error)
 	}
-	var tools []registry.ToolDesc
-	if b, err := json.Marshal(resp.Result); err == nil {
-		_ = json.Unmarshal(b, &tools)
+	var out struct {
+		Tools []registry.ToolDesc `json:"tools"`
 	}
-	if len(tools) != 1 || tools[0].Description != "echo a message" {
-		t.Fatalf("unexpected tools: %+v", tools)
+	if b, err := json.Marshal(resp.Result); err == nil {
+		_ = json.Unmarshal(b, &out)
+	}
+	if len(out.Tools) != 1 || out.Tools[0].Description != "echo a message" {
+		t.Fatalf("unexpected tools: %+v", out.Tools)
 	}
 }
 
@@ -193,12 +226,23 @@ func TestResourceRead(t *testing.T) {
 	if resp.Error != nil {
 		t.Fatalf("unexpected error: %v", resp.Error)
 	}
-	var out struct{ ID int }
+	var out struct {
+		Contents []struct {
+			URI      string `json:"uri"`
+			MimeType string `json:"mime_type"`
+			Text     string `json:"text"`
+		} `json:"contents"`
+	}
 	if b, err := json.Marshal(resp.Result); err == nil {
 		_ = json.Unmarshal(b, &out)
 	}
-	if out.ID != 42 {
+	if len(out.Contents) != 1 {
 		t.Fatalf("unexpected result: %+v", out)
+	}
+	var res struct{ ID int }
+	_ = json.Unmarshal([]byte(out.Contents[0].Text), &res)
+	if res.ID != 42 {
+		t.Fatalf("unexpected result: %+v", res)
 	}
 }
 

--- a/transport/http.go
+++ b/transport/http.go
@@ -42,6 +42,15 @@ func HTTPTransport(addr string) Transport {
 }
 
 func (h *httpTransport) handle(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodGet && r.Header.Get("Accept") == "text/event-stream" {
+		w.Header().Set("Content-Type", "text/event-stream")
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		<-r.Context().Done()
+		return
+	}
+
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/transport/http_test.go
+++ b/transport/http_test.go
@@ -131,11 +131,13 @@ func TestHTTPTransportEndToEnd(t *testing.T) {
 	if out.Error != nil {
 		t.Fatalf("unexpected error: %v", out.Error)
 	}
-	var tools []registry.ToolDesc
-	if b, err := json.Marshal(out.Result); err == nil {
-		_ = json.Unmarshal(b, &tools)
+	var result struct {
+		Tools []registry.ToolDesc `json:"tools"`
 	}
-	if len(tools) != 1 || tools[0].Name != "Echo" {
-		t.Fatalf("unexpected tools: %+v", tools)
+	if b, err := json.Marshal(out.Result); err == nil {
+		_ = json.Unmarshal(b, &result)
+	}
+	if len(result.Tools) != 1 || result.Tools[0].Name != "Echo" {
+		t.Fatalf("unexpected tools: %+v", result.Tools)
 	}
 }


### PR DESCRIPTION
## Summary
- require URI and handlers when registering resources and templates
- provide helper options only for schemas
- return templates without handlers
- update examples and tests
- add coverage for resource template listing

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6845d36388888321bb4deefbd6db0f5a