### PR TITLE
Clean up code and support resource templates

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -127,23 +127,34 @@ func (r *Registry) ResourcesMap() map[string]*ResourceDesc {
 	return out
 }
 
-func (r *Registry) findResource(uri string) *ResourceDesc {
+func (r *Registry) findResource(uri string) rawResourceHandler {
 	for _, res := range r.resources {
 		tmpl := res.URI
 		if tmpl == uri {
-			return res
+			return res.Handler
 		}
 		if i := strings.Index(tmpl, "{"); i > 0 {
 			prefix := tmpl[:i]
 			if strings.HasPrefix(uri, prefix) {
-				return res
+				return res.Handler
 			}
+		}
+	}
+	for _, res := range r.resourceTemplates {
+		tmpl := res.URITemplate
+		if i := strings.Index(tmpl, "{"); i > 0 {
+			prefix := tmpl[:i]
+			if strings.HasPrefix(uri, prefix) {
+				return res.Handler
+			}
+		} else if tmpl == uri {
+			return res.Handler
 		}
 	}
 	return nil
 }
 
-func (r *Registry) FindResource(uri string) *ResourceDesc {
+func (r *Registry) FindResource(uri string) rawResourceHandler {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.findResource(uri)

--- a/registry/resource_template.go
+++ b/registry/resource_template.go
@@ -1,9 +1,6 @@
 package registry
 
 import (
-	"context"
-	"reflect"
-
 	"github.com/cyrusaf/mcp/schema"
 )
 
@@ -11,33 +8,16 @@ type ResourceTemplateDesc struct {
 	Name        string             `json:"name"`
 	URITemplate string             `json:"uriTemplate"`
 	JSONSchema  *schema.Schema     `json:"json_schema,omitempty"`
+	Description *string            `json:"description,omitempty"`
 	Handler     rawResourceHandler `json:"-"`
-}
-
-type rawResourceTemplateHandler interface {
-	Resp() reflect.Type
-	Read(ctx context.Context, uri string) (any, error)
-}
-
-type resourceTemplateHandlerFunc[Resp any] struct {
-	f func(context.Context, string) (Resp, error)
-}
-
-func (h *resourceTemplateHandlerFunc[Resp]) Resp() reflect.Type {
-	var v Resp
-	return reflect.TypeOf(v)
-}
-
-func (h *resourceTemplateHandlerFunc[Resp]) Read(ctx context.Context, uri string) (any, error) {
-	return h.f(ctx, uri)
-}
-
-func ResourceTemplateHandlerFunc[Resp any](fn func(context.Context, string) (Resp, error)) rawResourceHandler {
-	return &resourceHandlerFunc[Resp]{f: fn}
 }
 
 type ResourceTemplateOption func(*ResourceTemplateDesc)
 
 func WithTemplateSchema(s *schema.Schema) ResourceTemplateOption {
 	return func(r *ResourceTemplateDesc) { r.JSONSchema = s }
+}
+
+func WithTemplateDescription(desc string) ResourceTemplateOption {
+	return func(r *ResourceTemplateDesc) { r.Description = &desc }
 }

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -142,12 +142,12 @@ func (s *Server) handleResourceRead(ctx context.Context, conn transport.Conn, re
 		s.sendError(ctx, conn, req.ID, ErrInvalidParams)
 		return
 	}
-	res := s.reg.FindResource(p.URI)
-	if res == nil || res.Handler == nil {
+	handler := s.reg.FindResource(p.URI)
+	if handler == nil {
 		s.sendError(ctx, conn, req.ID, ErrorMethodNotFound(p.URI))
 		return
 	}
-	val, err := res.Handler.Read(ctx, p.URI)
+	val, err := handler.Read(ctx, p.URI)
 	if err != nil {
 		s.sendError(ctx, conn, req.ID, &Error{Code: -32000, Message: err.Error()})
 		return

--- a/transport/http.go
+++ b/transport/http.go
@@ -43,11 +43,8 @@ func HTTPTransport(addr string) Transport {
 
 func (h *httpTransport) handle(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodGet && r.Header.Get("Accept") == "text/event-stream" {
-		w.Header().Set("Content-Type", "text/event-stream")
-		if f, ok := w.(http.Flusher); ok {
-			f.Flush()
-		}
-		<-r.Context().Done()
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "streaming not allowed on this endpoint", http.StatusMethodNotAllowed)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- support resource template descriptions and search them at runtime
- expose a Webpage resource in the demo
- remove unused types and debug prints
- disallow SSE requests in HTTP transport
- test resource template descriptions

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6845faa13a948321a3d8e6e4fcba5bc4