### PR TITLE
Fix resources/read response field names

### DIFF
--- a/rpc/resources.go
+++ b/rpc/resources.go
@@ -1,0 +1,22 @@
+package rpc
+
+import "encoding/json"
+
+// ResourceReadParams represents parameters to the "resources/read" JSON-RPC call.
+type ResourceReadParams struct {
+	URI  string          `json:"uri"`
+	Meta json.RawMessage `json:"_meta,omitempty"`
+}
+
+// ResourceContent represents an item in a resource read response.
+type ResourceContent struct {
+	URI      string `json:"uri"`
+	MimeType string `json:"mimeType"`
+	Text     string `json:"text,omitempty"`
+	Blob     string `json:"blob,omitempty"`
+}
+
+// ResourceReadResult represents the result payload of the "resources/read" call.
+type ResourceReadResult struct {
+	Contents []ResourceContent `json:"contents"`
+}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -134,11 +134,7 @@ func (s *Server) handleToolCall(ctx context.Context, conn transport.Conn, req rp
 }
 
 func (s *Server) handleResourceRead(ctx context.Context, conn transport.Conn, req rpcRequest) {
-	type params struct {
-		URI  string          `json:"uri"`
-		Meta json.RawMessage `json:"_meta,omitempty"`
-	}
-	var p params
+	var p ResourceReadParams
 	if err := json.Unmarshal(req.Params, &p); err != nil || p.URI == "" {
 		s.sendError(ctx, conn, req.ID, ErrInvalidParams)
 		return
@@ -159,12 +155,12 @@ func (s *Server) handleResourceRead(ctx context.Context, conn transport.Conn, re
 		return
 	}
 
-	out := map[string]any{
-		"contents": []any{
-			map[string]any{
-				"uri":       p.URI + "#json",
-				"mime_type": "application/json",
-				"text":      string(valJSON),
+	out := ResourceReadResult{
+		Contents: []ResourceContent{
+			{
+				URI:      p.URI,
+				MimeType: "application/json",
+				Text:     string(valJSON),
 			},
 		},
 	}

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -245,9 +245,7 @@ func TestResourceRead(t *testing.T) {
 	_, tr, cancel := startTestServer(t)
 	defer cancel()
 
-	params := struct {
-		URI string `json:"uri"`
-	}{URI: "res://42"}
+	params := ResourceReadParams{URI: "res://42"}
 	pbytes, _ := json.Marshal(params)
 	req := rpcRequest{JSONRPC: "2.0", ID: json.RawMessage(`5`), Method: "resources/read", Params: pbytes}
 	data, _ := json.Marshal(req)
@@ -261,13 +259,7 @@ func TestResourceRead(t *testing.T) {
 	if resp.Error != nil {
 		t.Fatalf("unexpected error: %v", resp.Error)
 	}
-	var out struct {
-		Contents []struct {
-			URI      string `json:"uri"`
-			MimeType string `json:"mime_type"`
-			Text     string `json:"text"`
-		} `json:"contents"`
-	}
+	var out ResourceReadResult
 	if b, err := json.Marshal(resp.Result); err == nil {
 		_ = json.Unmarshal(b, &out)
 	}


### PR DESCRIPTION
## Summary
- return `mimeType` instead of `mime_type`
- preserve the resource URI when reading
- add exported types for `resources/read` so tests can share

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6847c13a74788321bc693ccbcac24794